### PR TITLE
Default to HTTPS for both mvn repos and Maven Central

### DIFF
--- a/src/com/googlecode/shavenmaven/MvnArtifacts.java
+++ b/src/com/googlecode/shavenmaven/MvnArtifacts.java
@@ -32,7 +32,7 @@ public enum MvnArtifacts implements Artifacts { instance;
         }
 
     private static String repository(String host) {
-        return host == null ? defaultRepository() : "http:" + host;
+        return host == null ? defaultRepository() : "https:" + host;
     }
 
     public static final String KEY = "shavenmaven.default-repository";

--- a/src/com/googlecode/shavenmaven/MvnArtifacts.java
+++ b/src/com/googlecode/shavenmaven/MvnArtifacts.java
@@ -38,7 +38,7 @@ public enum MvnArtifacts implements Artifacts { instance;
     public static final String KEY = "shavenmaven.default-repository";
 
     public static String defaultRepository() {
-        return System.getProperty(KEY, "http://repo1.maven.org/maven2/");
+        return System.getProperty(KEY, "https://repo1.maven.org/maven2/");
     }
 
     public static String defaultRepository(String value) {

--- a/src/shavenmaven.xml
+++ b/src/shavenmaven.xml
@@ -37,7 +37,7 @@
 
         <sequential>
             <mkdir dir="@{directory}"/>
-            <get src="http://@{repo}/@{group}/@{artifact}/@{version}/@{artifact}-@{version}.@{extension}"
+            <get src="https://@{repo}/@{group}/@{artifact}/@{version}/@{artifact}-@{version}.@{extension}"
                  dest="@{directory}/@{artifact}.@{extension}" usetimestamp="true"/>
             <unpack input="@{directory}/@{artifact}.@{extension}" output="@{directory}/@{artifact}.jar"/>
             <delete file="@{directory}/@{artifact}.@{extension}"/>

--- a/src/shavenmaven.xml
+++ b/src/shavenmaven.xml
@@ -48,7 +48,7 @@
         <attribute name="dependencies"/>
         <attribute name="directory"/>
         <attribute name="shavenmaven.jar" default="lib/shavenmaven.jar"/>
-        <attribute name="default.repository" default="http://repo1.maven.org/maven2/"/>
+        <attribute name="default.repository" default="https://repo1.maven.org/maven2/"/>
 
         <sequential>
             <mkdir dir="@{directory}"/>

--- a/test/com/googlecode/shavenmaven/MvnArtifactTest.java
+++ b/test/com/googlecode/shavenmaven/MvnArtifactTest.java
@@ -19,7 +19,7 @@ public class MvnArtifactTest {
         assertThat(mvnArtifact.type(), is("pack"));
         assertThat(mvnArtifact.version(), is("1125"));
         assertThat(mvnArtifact.value().toString(), is("mvn://repo.bodar.com/someFolder/com.googlecode.totallylazy:totallylazy:pack|tests-pack:1125"));
-        assertThat(mvnArtifact.uri().toString(), is(new URL("http://repo.bodar.com/someFolder/com/googlecode/totallylazy/totallylazy/1125/totallylazy-1125.pack.gz").toString()));
+        assertThat(mvnArtifact.uri().toString(), is(new URL("https://repo.bodar.com/someFolder/com/googlecode/totallylazy/totallylazy/1125/totallylazy-1125.pack.gz").toString()));
         assertThat(mvnArtifact.filename(), is("totallylazy-1125.jar"));
 
         MvnArtifact tests = artifacts.second();
@@ -28,7 +28,7 @@ public class MvnArtifactTest {
         assertThat(tests.type(), is("tests-pack"));
         assertThat(tests.version(), is("1125"));
         assertThat(tests.value().toString(), is("mvn://repo.bodar.com/someFolder/com.googlecode.totallylazy:totallylazy:pack|tests-pack:1125"));
-        assertThat(tests.uri().toString(), is(new URL("http://repo.bodar.com/someFolder/com/googlecode/totallylazy/totallylazy/1125/totallylazy-1125-tests.pack.gz").toString()));
+        assertThat(tests.uri().toString(), is(new URL("https://repo.bodar.com/someFolder/com/googlecode/totallylazy/totallylazy/1125/totallylazy-1125-tests.pack.gz").toString()));
         assertThat(tests.filename(), is("totallylazy-1125-tests.jar"));
     }
 
@@ -48,7 +48,7 @@ public class MvnArtifactTest {
         assertThat(mvnArtifact.type(), is("jar"));
         assertThat(mvnArtifact.version(), is("116"));
         assertThat(mvnArtifact.value().toString(), is("mvn://repo.bodar.com/someFolder/com.googlecode.yadic:yadic:jar:116"));
-        assertThat(mvnArtifact.uri().toString(), is(new URL("http://repo.bodar.com/someFolder/com/googlecode/yadic/yadic/116/yadic-116.jar").toString()));
+        assertThat(mvnArtifact.uri().toString(), is(new URL("https://repo.bodar.com/someFolder/com/googlecode/yadic/yadic/116/yadic-116.jar").toString()));
         assertThat(mvnArtifact.filename(), is("yadic-116.jar"));
     }
 
@@ -103,7 +103,7 @@ public class MvnArtifactTest {
         assertThat(mvnArtifact.id(), is("yadic"));
         assertThat(mvnArtifact.type(), is("jar"));
         assertThat(mvnArtifact.version(), is("116"));
-        assertThat(mvnArtifact.uri().toString(), is(new URL("http://repo.bodar.com/com/googlecode/yadic/yadic/116/yadic-116.jar").toString()));
+        assertThat(mvnArtifact.uri().toString(), is(new URL("https://repo.bodar.com/com/googlecode/yadic/yadic/116/yadic-116.jar").toString()));
         assertThat(mvnArtifact.filename(), is("yadic-116.jar"));
     }
     
@@ -114,7 +114,7 @@ public class MvnArtifactTest {
         assertThat(mvnArtifact.id(), is("yadic"));
         assertThat(mvnArtifact.type(), is("classifier"));
         assertThat(mvnArtifact.version(), is("116"));
-        assertThat(mvnArtifact.uri().toString(), is(new URL("http://repo.bodar.com/com/googlecode/yadic/yadic/116/yadic-116-classifier.jar").toString()));
+        assertThat(mvnArtifact.uri().toString(), is(new URL("https://repo.bodar.com/com/googlecode/yadic/yadic/116/yadic-116-classifier.jar").toString()));
         assertThat(mvnArtifact.filename(), is("yadic-116-classifier.jar"));
     }
 }

--- a/test/com/googlecode/shavenmaven/MvnArtifactTest.java
+++ b/test/com/googlecode/shavenmaven/MvnArtifactTest.java
@@ -61,7 +61,7 @@ public class MvnArtifactTest {
         assertThat(jar.type(), is("jar"));
         assertThat(jar.version(), is("1.2"));
         assertThat(jar.value().toString(), is("mvn:org.objenesis:objenesis:jar|sources:1.2"));
-        assertThat(jar.uri().toString(), is(new URL("http://repo1.maven.org/maven2/org/objenesis/objenesis/1.2/objenesis-1.2.jar").toString()));
+        assertThat(jar.uri().toString(), is(new URL("https://repo1.maven.org/maven2/org/objenesis/objenesis/1.2/objenesis-1.2.jar").toString()));
         assertThat(jar.filename(), is("objenesis-1.2.jar"));
 
         MvnArtifact second = mvnArtifact.second();
@@ -70,7 +70,7 @@ public class MvnArtifactTest {
         assertThat(second.type(), is("sources"));
         assertThat(second.version(), is("1.2"));
         assertThat(second.value().toString(), is("mvn:org.objenesis:objenesis:jar|sources:1.2"));
-        assertThat(second.uri().toString(), is(new URL("http://repo1.maven.org/maven2/org/objenesis/objenesis/1.2/objenesis-1.2-sources.jar").toString()));
+        assertThat(second.uri().toString(), is(new URL("https://repo1.maven.org/maven2/org/objenesis/objenesis/1.2/objenesis-1.2-sources.jar").toString()));
         assertThat(second.filename(), is("objenesis-1.2-sources.jar"));
     }
 
@@ -81,7 +81,7 @@ public class MvnArtifactTest {
         assertThat(mvnArtifact.id(), is("sitemesh"));
         assertThat(mvnArtifact.type(), is("jar"));
         assertThat(mvnArtifact.version(), is("3.0-alpha-2"));
-        assertThat(mvnArtifact.uri().toString(), is(new URL("http://repo1.maven.org/maven2/org/sitemesh/sitemesh/3.0-alpha-2/sitemesh-3.0-alpha-2.jar").toString()));
+        assertThat(mvnArtifact.uri().toString(), is(new URL("https://repo1.maven.org/maven2/org/sitemesh/sitemesh/3.0-alpha-2/sitemesh-3.0-alpha-2.jar").toString()));
         assertThat(mvnArtifact.filename(), is("sitemesh-3.0-alpha-2.jar"));
     }
 
@@ -92,7 +92,7 @@ public class MvnArtifactTest {
         assertThat(mvnArtifact.id(), is("objenesis"));
         assertThat(mvnArtifact.type(), is("jar"));
         assertThat(mvnArtifact.version(), is("1.2"));
-        assertThat(mvnArtifact.uri().toString(), is(new URL("http://repo1.maven.org/maven2/org/objenesis/objenesis/1.2/objenesis-1.2.jar").toString()));
+        assertThat(mvnArtifact.uri().toString(), is(new URL("https://repo1.maven.org/maven2/org/objenesis/objenesis/1.2/objenesis-1.2.jar").toString()));
         assertThat(mvnArtifact.filename(), is("objenesis-1.2.jar"));
     }
 

--- a/test/com/googlecode/shavenmaven/S3ArtifactTest.java
+++ b/test/com/googlecode/shavenmaven/S3ArtifactTest.java
@@ -26,10 +26,10 @@ public class S3ArtifactTest {
         assertThat(s3Artifact.type(), is("jar"));
         assertThat(s3Artifact.version(), is("116"));
         assertThat(s3Artifact.value().toString(), is("s3://repo.bodar.com/com.googlecode.yadic:yadic:jar:116"));
-        assertThat(s3Artifact.uri().toString(), is(new URL("http://repo.bodar.com.s3.amazonaws.com/com/googlecode/yadic/yadic/116/yadic-116.jar").toString()));
-        assertThat(s3Artifact.request().uri().toString(), is(new URL("http://repo.bodar.com.s3.amazonaws.com/com/googlecode/yadic/yadic/116/yadic-116.jar").toString()));
+        assertThat(s3Artifact.uri().toString(), is(new URL("https://repo.bodar.com.s3.amazonaws.com/com/googlecode/yadic/yadic/116/yadic-116.jar").toString()));
+        assertThat(s3Artifact.request().uri().toString(), is(new URL("https://repo.bodar.com.s3.amazonaws.com/com/googlecode/yadic/yadic/116/yadic-116.jar").toString()));
         assertThat(s3Artifact.filename(), is("yadic-116.jar"));
-        assertThat(s3Artifact.toString(), is("http://repo.bodar.com.s3.amazonaws.com/com/googlecode/yadic/yadic/116/yadic-116.jar (s3://repo.bodar.com/com.googlecode.yadic:yadic:jar:116)"));
+        assertThat(s3Artifact.toString(), is("https://repo.bodar.com.s3.amazonaws.com/com/googlecode/yadic/yadic/116/yadic-116.jar (s3://repo.bodar.com/com.googlecode.yadic:yadic:jar:116)"));
     }
 
     @Test
@@ -37,7 +37,7 @@ public class S3ArtifactTest {
         Date now = date(2001, 1, 1);
         S3Artifacts s3Artifacts = S3Artifacts.s3Artifacts(new StoppedClock(now), sequence(awsCredentials("*", "access-key", "secret-key")));
         Request request = s3Artifacts.parse("s3://repo.bodar.com/com.googlecode.yadic:yadic:jar:116").head().request();
-        assertThat(request.uri().toString(), Matchers.is("http://repo.bodar.com.s3.amazonaws.com/com/googlecode/yadic/yadic/116/yadic-116.jar"));
+        assertThat(request.uri().toString(), Matchers.is("https://repo.bodar.com.s3.amazonaws.com/com/googlecode/yadic/yadic/116/yadic-116.jar"));
         assertThat(request.headers().getValue(AUTHORIZATION), Matchers.is("AWS access-key:64kyKI1P/MEwS3PaO46uEBBDbUM="));
     }
 }


### PR DESCRIPTION
Morning - hope all is well in these turbulent times!

Maven Central now rejects HTTP connections, as do a few of the other repos. This ensures that we default to HTTPS so we can build things without overriding the default repo.